### PR TITLE
Add GitHub workflow to check all links every month

### DIFF
--- a/.github/workflows/links_checker.yml
+++ b/.github/workflows/links_checker.yml
@@ -1,0 +1,87 @@
+name: Links Checker
+
+on:
+  ## Allow triggering this workflow manually via GitHub CLI/web
+  workflow_dispatch:
+
+  ## Run this workflow automatically every month
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  link_checker:
+    name: Check links and create an automated issue, if needed
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      REPORT_FILE: links-report
+    steps:
+      ## Check out code using Git
+      - uses: actions/checkout@v2
+
+      - name: Check all links at README.md file
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.2.0
+        with:
+          output: ${{ env.REPORT_FILE }}
+          format: markdown
+          ## Do not fail this step on broken links
+          fail: false
+          ## Allow pages replying with 200 (OK), 204 (No Content),
+          ## 206 (Partial Content), 400 (Bad Request), 403 (Forbidden),
+          ## 500 (Internal Server Error), 502 (Bad Gateway), or 504 (Gateway Timeout)
+          ## in at most 20 seconds with HTML content.
+          args: >-
+            --verbose
+            --accept 200,204,206,400,403,500,502,504
+            --headers "accept=text/html"
+            --timeout 20
+            --max-concurrency 128
+            --no-progress
+            README.md
+        env:
+          ## Avoid rate limiting when checking github.com links
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lychee's exit code
+        ## https://github.com/lycheeverse/lychee#exit-codes
+        run: echo Lychee exit with ${{ steps.lychee.outputs.exit_code }}
+
+      - name: Find the last report issue open
+        uses: micalevisk/last-issue-action@v1
+        id: last_issue
+        with:
+          state: open
+          labels: |
+            report
+            automated issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create issue from report file
+        if: ${{ steps.last_issue.outputs.has_found == 'false' }}
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: Link checker report
+          content-filepath: ${{ env.REPORT_FILE }}
+          issue-number: ${{ steps.last_issue.outputs.issue_number }}
+          labels: |
+            report
+            automated issue
+
+      - name: Update last report open issue created
+        if: ${{ steps.last_issue.outputs.has_found == 'true' }}
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: Link checker report
+          content-filepath: ${{ env.REPORT_FILE }}
+          issue-number: ${{ steps.last_issue.outputs.issue_number }}
+          labels: |
+            report
+            automated issue
+
+      - name: Close last report open issue
+        if: ${{ steps.lychee.outputs.exit_code == 0 }}
+        uses: peter-evans/close-issue@v1
+        with:
+          issue-number: ${{ steps.last_issue.outputs.issue_number }}


### PR DESCRIPTION
I don't know if you're looking for this, feel free to close then.

I've used https://github.com/lycheeverse/lychee-action to automatically create an issue reporting all 'bad' links found on `README.md`. Here's an example of an issue: https://github.com/micalevisk/backend-challenges/issues/3 that I've got after running this workflow manually on my fork

![image](https://user-images.githubusercontent.com/13461315/146684316-4bebb942-dbd6-4e19-b994-a88a47df293d.png)

This issue will be created only if there's some bad link on `README.md` file.

Besides that, this workflow will find the last open issue with the labels _report_ and _automated issue_, and update it instead of creating a new one. Or will close it if there's no bad link found (meaning the Issue was stale).

Also, the workflow will run once in a month or can be triggered manually, and must takes at most 10 minutes, to prevent exceding your quota on GitHub Actions. You can change this, of course :)